### PR TITLE
Support multiple independent disclaimer messages

### DIFF
--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -15,7 +15,7 @@ const PersonIcon = ({
   race = "",
   scale = 1,
   curDisclaimers = [],
-  onDisclaimerChange = () => {},
+  onDisclaimersChange = () => {},
 }) => {
   const valueRoof = Math.ceil(value);
   const maskHeight = {

--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -81,7 +81,7 @@ const PersonIcon = ({
 const CHART_DISCLAIMER = {
   n_a: "A displayed value of N/A indicates there are 10 or fewer underlying observations for at least one of the variables needed to compute the metric.",
   zero: "A displayed value of 0.00 means that sufficient data is available, but the value is less than 0.005.",
-  d_gap: "No disparity gap per prior event information is available for arrests.",
+  pep: "No rate per prior event information is available for arrests because arrests are the beginning of the process.",
 }
 
 const SCALE = {
@@ -118,7 +118,7 @@ const IconCharInner = ({ chartData, races, base, measurement }) => {
   let disclaimers = {
     n_a: false,
     zero: false,
-    d_gap: measurement.indexOf("Disparity gap per prior") > -1,
+    pep: measurement.indexOf("prior event point") > -1,
   };
 
   let scale = 1;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -120,13 +120,6 @@ const Select = ({
                   }
                 />{" "}
                 {option.text}
-                {label === "Measurement" &&
-                  option.text === "Rate per prior event point" && (
-                    <div className="description">
-                      No rate per prior event information is available for
-                      arrests because arrests are the beginning of the process.
-                    </div>
-                  )}
               </li>
             ))}
           </ul>

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -232,7 +232,8 @@ export default function App() {
     setLoading(true);
     const parser = new PublicGoogleSheetsParser();
     parser
-      .parse("1j9YBu-u-5tTgEAUy7uP9NmHdSLEwDVKWZJsMDTvAPXQ", sheet)
+      //.parse("1j9YBu-u-5tTgEAUy7uP9NmHdSLEwDVKWZJsMDTvAPXQ", sheet)
+      .parse("1qFsF5ivZUHDRsst4sHZYt_eMZypO93eYUpXT1XBQYYQ", sheet)
       .then((originItems) => {
         let _years = [];
         const _decisionPoints = [];

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -208,8 +208,6 @@ export default function App() {
                 let temp = acc[k] + (dd.items[k] || 0);
                 if (measurement === "Raw numbers") {
                   temp = Math.ceil(temp);
-                } else {
-                  temp = Number(Number(temp).toFixed(2));
                 }
                 acc[k] = temp;
                 return acc;

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -462,7 +462,7 @@ export default function App() {
 
       filter({
         races,
-        genders,
+        //genders,
         decisionPoints,
         offenses,
         years,

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -134,17 +134,17 @@ export default function App() {
     records = fullRecords,
   ) => {
     const allowedEventPoints = [
-      "Charge",
+      "Court",
       "Conviction",
       "Prison sentence",
       "Felony conviction",
     ];
     const raw = records.filter((r) => {
       if (
-        measurement === "Rate per prior event point" &&
+        measurement.indexOf("prior event point") > -1 &&
         !allowedEventPoints.includes(r["Event Point"])
       ) {
-        // Exclude records with measurement "Rate per prior event point" and other event points
+        // Exclude arrest data from "prior event point" metrics
         return false;
       }
       if (races.length > 0 && !races.includes(r.Race)) {
@@ -252,13 +252,10 @@ export default function App() {
           item["Rate per prior event point"] = isNaN(item.rate_cond_previous)
             ? 0
             : item.rate_cond_previous;
-
           item["Disparity gap per population"] = isNaN(item.disparity_gap_pop_w)
             ? 0
             : item.disparity_gap_pop_w;
-          item["Disparity gap per prior event point"] = isNaN(
-            item.disparity_gap_cond_w,
-          )
+          item["Disparity gap per prior event point"] = isNaN(item.disparity_gap_cond_w)
             ? 0
             : item.disparity_gap_cond_w;
           return item;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -472,7 +472,7 @@
   }
 
   .icon-person-placeholder {
-    height: 10px;
+    height: 0px;
   }
 
   .icon-chart-label {


### PR DESCRIPTION
This changes the way disclaimers work a little bit, so they should appear if and only if they are relevant. It gets rid of the disclaimer state object and has IconCharInner handle everything.

The error messages that display conditionally are the following:

- “A displayed value of N/A indicates there are 10 or fewer underlying observations for at least one of the variables needed to compute the metric.”
- “A displayed value of 0.00 means that sufficient data is available, but the value is less than 0.005.”
- “No disparity gap per prior event information is available for arrests.” (Only displays when “Disparity gap per prior decision point” is being shown).

This also fixes the discrepancy between N/A and 0.00: N/A will display if and only if there is insufficient data to compute a data point, and 0.00 will display if the computed value is less than 0.005. The unrounded, raw value is passed to PersonIcon and rounded just before rendering.

Finally, this changes how numbers are formatted a little bit. Numbers are now always rounded to 3 significant figures. Produces output like the following: 
- 132k
- 12.1k
- 3.14k
- 10.1
- 0.04