### PR TITLE
Change scaling for rate per population and per prior event 

### DIFF
--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -15,7 +15,7 @@ const PersonIcon = ({
   race = "",
   scale = 1,
   curDisclaimers = [],
-  onDisclaimerChange = () => {},
+  onDisclaimersChange = () => {},
 }) => {
   const valueRoof = Math.ceil(value);
   const maskHeight = {

--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -81,7 +81,7 @@ const PersonIcon = ({
 const CHART_DISCLAIMER = {
   n_a: "A displayed value of N/A indicates there are 10 or fewer underlying observations for at least one of the variables needed to compute the metric.",
   zero: "A displayed value of 0.00 means that sufficient data is available, but the value is less than 0.005.",
-  d_gap: "No disparity gap per prior event information is available for arrests.",
+  pep: "No rate per prior event information is available for arrests because arrests are the beginning of the process.",
 }
 
 const SCALE = {
@@ -118,7 +118,7 @@ const IconCharInner = ({ chartData, races, base, measurement }) => {
   let disclaimers = {
     n_a: false,
     zero: false,
-    d_gap: measurement.indexOf("Disparity gap per prior") > -1,
+    pep: measurement.indexOf("prior event point") > -1,
   };
 
   let scale = 1;

--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -62,7 +62,7 @@ const PersonIcon = ({
           <div className="icon-chart-data-point">
             <div className="icon-person icon-person-placeholder" />
             <span className="icon-chart-data-point-mask">
-              <div className="icon-chart-data-label">0.00</div>
+              <div className="icon-chart-data-label">{formatNumber(label)}</div>
             </span>
           </div>
         ) : (
@@ -169,7 +169,7 @@ const IconCharInner = ({ chartData, races, base, measurement }) => {
         }
         const _scaled = (yd.items[k] / scale).toFixed(2);
 
-        if (Math.ceil(_scaled) === 0) {
+        if (_origin < 0.005) {
           if (_origin > 0) {
             disclaimers.zero = true;
           } else {

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -120,13 +120,6 @@ const Select = ({
                   }
                 />{" "}
                 {option.text}
-                {label === "Measurement" &&
-                  option.text === "Rate per prior event point" && (
-                    <div className="description">
-                      No rate per prior event information is available for
-                      arrests because arrests are the beginning of the process.
-                    </div>
-                  )}
               </li>
             ))}
           </ul>

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -232,7 +232,8 @@ export default function App() {
     setLoading(true);
     const parser = new PublicGoogleSheetsParser();
     parser
-      .parse("1j9YBu-u-5tTgEAUy7uP9NmHdSLEwDVKWZJsMDTvAPXQ", sheet)
+      //.parse("1j9YBu-u-5tTgEAUy7uP9NmHdSLEwDVKWZJsMDTvAPXQ", sheet)
+      .parse("1qFsF5ivZUHDRsst4sHZYt_eMZypO93eYUpXT1XBQYYQ", sheet)
       .then((originItems) => {
         let _years = [];
         const _decisionPoints = [];

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -208,8 +208,6 @@ export default function App() {
                 let temp = acc[k] + (dd.items[k] || 0);
                 if (measurement === "Raw numbers") {
                   temp = Math.ceil(temp);
-                } else {
-                  temp = Number(Number(temp).toFixed(2));
                 }
                 acc[k] = temp;
                 return acc;

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -462,7 +462,7 @@ export default function App() {
 
       filter({
         races,
-        genders,
+        //genders,
         decisionPoints,
         offenses,
         years,

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -134,17 +134,17 @@ export default function App() {
     records = fullRecords,
   ) => {
     const allowedEventPoints = [
-      "Charge",
+      "Court",
       "Conviction",
       "Prison sentence",
       "Felony conviction",
     ];
     const raw = records.filter((r) => {
       if (
-        measurement === "Rate per prior event point" &&
+        measurement.indexOf("prior event point") > -1 &&
         !allowedEventPoints.includes(r["Event Point"])
       ) {
-        // Exclude records with measurement "Rate per prior event point" and other event points
+        // Exclude arrest data from "prior event point" metrics
         return false;
       }
       if (races.length > 0 && !races.includes(r.Race)) {
@@ -252,13 +252,10 @@ export default function App() {
           item["Rate per prior event point"] = isNaN(item.rate_cond_previous)
             ? 0
             : item.rate_cond_previous;
-
           item["Disparity gap per population"] = isNaN(item.disparity_gap_pop_w)
             ? 0
             : item.disparity_gap_pop_w;
-          item["Disparity gap per prior event point"] = isNaN(
-            item.disparity_gap_cond_w,
-          )
+          item["Disparity gap per prior event point"] = isNaN(item.disparity_gap_cond_w)
             ? 0
             : item.disparity_gap_cond_w;
           return item;

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -9,14 +9,12 @@ import Grid from "@/components/Grid";
 
 const MEASUREMENTS_MAP = {
   "Raw numbers": "Raw numbers",
-  "Rate per population": "Rate per 1,000 adults",
+  "Rate per population": "Rate per unit population",
   "Rate per prior event point": "Rate per prior decision point",
-  "Disparity gap per population": "Disparity gap per 1,000 adults",
+  "Disparity gap per population": "Disparity gap vs. white adults",
   "Disparity gap per prior event point":
     "Disparity gap per prior decision point",
 };
-
-const MEASUREMENTS = Object.keys(MEASUREMENTS_MAP);
 
 const RACES = {
   White: "White",
@@ -251,7 +249,7 @@ export default function App() {
             : item.rate_per_100_pop;
           item["Rate per prior event point"] = isNaN(item.rate_cond_previous)
             ? 0
-            : item.rate_cond_previous;
+            : item.rate_cond_previous / 100;
           item["Disparity gap per population"] = isNaN(item.disparity_gap_pop_w)
             ? 0
             : item.disparity_gap_pop_w;
@@ -556,7 +554,7 @@ export default function App() {
             label="Measurement"
             value={measurement}
             onChange={onMeasurementsChange}
-            options={MEASUREMENTS.map((m) => ({
+            options={Object.keys(MEASUREMENTS_MAP).map((m) => ({
               text: m,
               value: m,
             }))}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -472,7 +472,7 @@
   }
 
   .icon-person-placeholder {
-    height: 10px;
+    height: 0px;
   }
 
   .icon-chart-label {


### PR DESCRIPTION
This builds on the "multiple disclaimers" PR from earlier.
Rate per population can now scale down to display more data.
In addition, divide rate per prior event point by 100 (it was previously calculated as a percentage) to make it consistent with disparity gap per prior event point display.
Fix a bug which caused small numbers to incorrectly display as 0.00 when the scaling factor was high enough.