### PR TITLE
Persist filters across county selection

### DIFF
--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -143,38 +143,33 @@ const IconCharInner = ({ chartData, races, base, measurement }) => {
 
   let scale = 1;
 
-  const isRawNumber = [
-    MEASUREMENTS.RAW,
-    MEASUREMENTS.RATE,
-    MEASUREMENTS.R_PEP,
-  ].includes(measurement);
-
   if (measurement === MEASUREMENTS.RAW) {
     scale = scaleUp(chartData.data);
   } else if (measurement === MEASUREMENTS.RATE) {
     scale = scaleDown(chartData.data);
   }
 
-  const yearData = JSON.parse(JSON.stringify({
-    ...chartData,
-  }));
+  const filteredRaces = Object.keys(races).filter(
+    (raceItem) => raceItem.toLowerCase() !== base);
 
-  const scaledYearData = yearData.data.map((yd) => {
+  const scaledYearData = chartData.data.map((yd) => {
     return {
       label: yd.label,
-      items: Object.keys(yd.items).reduce((acc, k) => {
+      items: filteredRaces.reduce((acc, k) => {
+        if (!(k in yd.items)) {
+          disclaimers.n_a = true;
+          acc[k] = {scaled: 0, origin: 0, scale: 1};
+          return acc;
+        }
+
         let _origin = yd.items[k];
         if (scale < 1) {
           _origin /= scale;
         }
         const _scaled = (yd.items[k] / scale).toFixed(2);
 
-        if (_origin < 0.005) {
-          if (_origin > 0) {
-            disclaimers.zero = true;
-          } else {
-            disclaimers.n_a = true;
-          }
+        if (_origin < 0.005 && _origin > 0) {
+          disclaimers.zero = true;
         }
 
         acc[k] = {
@@ -196,9 +191,9 @@ const IconCharInner = ({ chartData, races, base, measurement }) => {
   }
 
   return (
-    <div className="icon-chart" key={yearData.year}>
+    <div className="icon-chart" key={chartData.year}>
       <h3>
-        {yearData.year}
+        {chartData.year}
         <div className="chart-meta">
           <div className="chart-scale">
             <PersonIcon value={1} race={base} scale={1} /> {scaleString}{" "}
@@ -207,9 +202,7 @@ const IconCharInner = ({ chartData, races, base, measurement }) => {
         </div>
       </h3>
       <div className="icon-chart-races-container">
-        {Object.keys(races)
-          .filter((raceItem) => raceItem.toLowerCase() !== base)
-          .map((raceItem) => {
+        {filteredRaces.map((raceItem) => {
             return (
               <div className="icon-chart-race-container" key={raceItem}>
                 <h4>{races[raceItem]}</h4>

--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -144,6 +144,10 @@ const IconChartInner = ({ yearData, races, eventPoints, base, measurement }) => 
   const filteredRaces = Object.keys(races).filter(
     (raceItem) => raceItem.toLowerCase() !== base);
 
+  const filteredEventPoints = eventPoints.filter(
+    (ep) => !([MEASUREMENTS.R_PEP, MEASUREMENTS.DG_PEP].includes(measurement) &&
+              ep === "Arrest"));
+
   // yearData.data is an array of objects; each object corresponds to an event
   // point and contains a list of records for each race.
   // We're going to unpack it and construct an object of the form:
@@ -156,7 +160,7 @@ const IconChartInner = ({ yearData, races, eventPoints, base, measurement }) => 
   //   }
   // }
   const scaledData = {};
-  eventPoints.forEach((ep) => {
+  filteredEventPoints.forEach((ep) => {
     const eventData = yearData.data.filter((d) => d.label == ep);
 
     if (eventData.length === 0) {
@@ -224,7 +228,7 @@ const IconChartInner = ({ yearData, races, eventPoints, base, measurement }) => 
                       <PersonIcon value={1} race={base} label={1}/>
                     </div>
                   )}
-                  {eventPoints.map((ep, ix) => {
+                  {filteredEventPoints.map((ep, ix) => {
                     return (
                       <div className="icon-chart-row" key={ix}>
                         <div className="icon-chart-label">{ep}</div>

--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -58,21 +58,14 @@ const PersonIcon = ({
           );
         })
       ) : (
-        label > 0 ? (
-          <div className="icon-chart-data-point">
-            <div className="icon-person icon-person-placeholder" />
-            <span className="icon-chart-data-point-mask">
-              <div className="icon-chart-data-label">{formatNumber(label)}</div>
-            </span>
-          </div>
-        ) : (
-          <div className="icon-chart-data-point">
-            <div className="icon-person icon-person-placeholder" />
-              <span className="icon-chart-data-point-mask">
-              <div className="icon-chart-data-label">N/A</div>
-            </span>
-          </div>
-        )
+        <div className="icon-chart-data-point">
+          <div className="icon-person icon-person-placeholder" />
+          <span className="icon-chart-data-point-mask">
+            <div className="icon-chart-data-label">
+              {label > 0 ? formatNumber(label) : "N/A"}
+            </div>
+          </span>
+        </div>
       )}
     </div>
   );
@@ -109,7 +102,7 @@ const SCALE = {
 const scaleDown = (data) => {
   let max = 0;
 
-  // find smallest values present in data
+  // find largest value present in data
   data.forEach(({items}) => {
     max = Math.max(...Object.values(items), max);
   });
@@ -125,7 +118,7 @@ const scaleDown = (data) => {
 const scaleUp = (data) => {
   let max = 0;
 
-  // find largest & smallest values present in data
+  // find largest value present in data
   data.forEach(({items}) => {
     max = Math.max(...Object.values(items), max);
   });
@@ -175,7 +168,6 @@ const IconCharInner = ({ chartData, races, base, measurement }) => {
         acc[k] = {
           scaled: _scaled,
           origin: _origin,
-          scale,
         };
         return acc;
       }, {}),

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -551,7 +551,6 @@ export default function App() {
             }))}
           />
         </div>
-
         <div className="filter">
           <PrivateSelect
             label="Offenses"
@@ -606,22 +605,28 @@ export default function App() {
           <div className="loading-animation-centered">
             <Grid />
           </div>
-        ) : decisionPoints.length === 0 ? (
-          <div style={{ textAlign: "center", fontWeight: "bold" }}>
-            Select an Event Point.
-          </div>
-        ) : filteredRecords.chart.length === 0 ? (
-          <div style={{ textAlign: "center", fontWeight: "bold" }}>
-            Unable to display due to insufficient data.
-          </div>
-        ) : (
-          <IconCharts
-            data={filteredRecords.chart}
-            races={Object.fromEntries(Object.entries(RACES).filter(([key]) => races.includes(key)))}
-            base={chartConfig.base}
-            measurement={measurement}
-          />
-        )}
+        ) : (filteredRecords.chart.length > 0 ? (
+            <IconCharts
+              data={filteredRecords.chart}
+              races={Object.fromEntries(Object.entries(RACES).filter(([key]) =>
+                                        races.includes(key)))}
+              base={chartConfig.base}
+              measurement={measurement}
+            />
+          ) : (
+            <div style={{ textAlign: "center", fontWeight: "bold" }}>
+              <p>Unable to display due to insufficient data.</p>
+              {years.length === 0 && (
+                <p>Select at least one year.</p>
+              )}
+              {decisionPoints.length === 0 && (
+                <p>Select at least one event point.</p>
+              )}
+              {races.length === 0 && (
+                <p>Select at least one race.</p>
+              )}
+            </div>
+        ))}
       </div>
 
       {/* <pre>{JSON.stringify(filteredRecords, null, 4)}</pre> */}

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -112,8 +112,8 @@ export default function App() {
   const [offenses, setOffenses] = useState([]);
   //const [gendersAvailable, setGendersAvailable] = useState([]);
   //const [genders, setGenders] = useState([]);
-  const [races, setRaces] = useState(Object.keys(RACES));
   const [racesAvailable, setRacesAvailable] = useState([]);
+  const [races, setRaces] = useState(Object.keys(RACES));
   const [measurement, setMeasurement] = useState("Raw numbers");
   const [chartConfig, setChartConfig] = useState({
     ratio: 1,
@@ -138,7 +138,7 @@ export default function App() {
   };
 
   const filter = (
-    { decisionPoints, races, offenses, years, measurement, genders },
+    { decisionPoints, races, offenses, years, measurement /*, genders*/ },
     records = fullRecords,
   ) => {
     const allowedEventPoints = [
@@ -238,7 +238,7 @@ export default function App() {
 
   // https://docs.google.com/spreadsheets/d/1nJ3k0KXVrhXm8La-lOTpw8U7xL7Cc-GioANxxH5KsXE/edit#gid=0
   // Make sure share this link to the public, so anyone who has the link can open this spreedsheet
-  const fetchData = async (sheet, useDefaults = false) => {
+  const fetchData = async (sheet, useDefaults) => {
     setLoading(true);
     const parser = new PublicGoogleSheetsParser();
     parser
@@ -246,9 +246,9 @@ export default function App() {
       .parse("1qFsF5ivZUHDRsst4sHZYt_eMZypO93eYUpXT1XBQYYQ", sheet)
       .then((originItems) => {
         let _years = [];
-        const _decisionPoints = [];
-        const _offenses = [];
-        const _races = [];
+        let _decisionPoints = [];
+        let _offenses = [];
+        let _races = [];
         //const _genders = [];
 
         const items = originItems.map((item) => {
@@ -304,42 +304,44 @@ export default function App() {
         const defaultOffense = "459 PC-BURGLARY";
         //const defaultGender = _genders[0];
 
-        setYearsAvailable(_years);
-        setDecisionPointsAvailable(_decisionPoints);
-        setOffensesAvailable(_offenses);
-        setRacesAvailable(_races);
-        //setGendersAvailable(_genders);
+        setYearsAvailable([..._years]);
+        setDecisionPointsAvailable([..._decisionPoints]);
+        setOffensesAvailable([..._offenses]);
+        setRacesAvailable([..._races]);
+        //setGendersAvailable([..._genders]);
 
         if (useDefaults) {
-          setYears([mostRecentYear]);
-          setDecisionPoints(_decisionPoints);
-          setOffenses([defaultOffense]);
-          setRaces(_races);
-          //setGenders([defaultGender]);
+          _years = [mostRecentYear];
+          _offenses = [defaultOffense];
         } else {
           // Update filters: choose all items which were selected by the user AND
           // are present in the dataset
-          setYears(years.filter((y) => _years.includes(y)));
-          setDecisionPoints(decisionPoints.filter((d) =>
-                            _decisionPoints.includes(d)));
-          setOffenses(_offenses.includes(offenses[0]) ?
-                      [offenses[0]] : [defaultOffense]);
-          setRaces(races.filter((r) => _races.includes(r)));
+          _years = years.filter((y) => _years.includes(y));
+          _decisionPoints = decisionPoints.filter((d) =>
+                              _decisionPoints.includes(d));
+          _offenses = _offenses.includes(offenses[0]) ?
+                      [offenses[0]] : [defaultOffense];
+          _races = races.filter((r) => _races.includes(r));
         }
 
-        setLoading(false);
+        setYears([..._years]);
+        setDecisionPoints([..._decisionPoints]);
+        setOffenses([..._offenses]);
+        setRaces([..._races]);
 
         filter(
           {
-            decisionPoints: decisionPoints,
-            races: races,
-            offenses: offenses,
-            years: years,
+            decisionPoints: _decisionPoints,
+            races: _races,
+            offenses: _offenses,
+            years: _years,
             measurement: measurement,
             //genders: genders,
           },
           items,
         );
+
+        setLoading(false);
       });
   };
 
@@ -350,7 +352,7 @@ export default function App() {
 
   const onCountyChange = async (value) => {
     setCounty(value);
-    await fetchData(value);
+    await fetchData(value, false);
     filter({
       decisionPoints: decisionPoints,
       races: races,

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -147,21 +147,17 @@ export default function App() {
       "Prison sentence",
       "Felony conviction",
     ];
+
     const raw = records.filter((r) => {
-      if (
-        measurement.indexOf("prior event point") > -1 &&
-        !allowedEventPoints.includes(r["Event Point"])
-      ) {
-        // Exclude arrest data from "prior event point" metrics
+      if (measurement.indexOf("prior event point") > -1 &&
+          !allowedEventPoints.includes(r["Event Point"])) {
         return false;
       }
       if (races.length > 0 && !races.includes(r.Race)) {
         return false;
       }
-      if (
-        decisionPoints.length > 0 &&
-        !decisionPoints.includes(r["Event Point"])
-      ) {
+      if (decisionPoints.length > 0 &&
+          !decisionPoints.includes(r["Event Point"])) {
         return false;
       }
       if (offenses.length > 0 && !offenses.includes(r.Offenses)) {
@@ -628,6 +624,7 @@ export default function App() {
               data={filteredRecords.chart}
               races={Object.fromEntries(Object.entries(RACES).filter(([key]) =>
                                         races.includes(key)))}
+              eventPoints={decisionPoints}
               base={chartConfig.base}
               measurement={measurement}
             />

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -7,6 +7,14 @@ import DataTable from "@/components/DataTable";
 import PrivateSelect from "@/components/Select";
 import Grid from "@/components/Grid";
 
+const MEASUREMENTS = {
+  RAW: "Raw numbers",
+  RATE: "Rate per population",
+  R_PEP: "Rate per prior event point",
+  DG: "Disparity gap per population",
+  DG_PEP: "Disparity gap per prior event point",
+};
+
 const MEASUREMENTS_MAP = {
   "Raw numbers": "Raw numbers",
   "Rate per population": "Rate per unit population",
@@ -292,10 +300,10 @@ export default function App() {
         });
         //const defaultGender = _genders[0];
         const mostRecentYear = _years[0];
-        // const defaultOffense = _offenses[0];
+        //const defaultOffense = _offenses[0];
         setYears([mostRecentYear]);
         setYearsAvailable(_years);
-        // setGendersAvailable(_genders);
+        //setGendersAvailable(_genders);
         //setGenders([defaultGender]);
         setDecisionPointsAvailable(_decisionPoints);
         setDecisionPoints(_decisionPoints);
@@ -328,24 +336,24 @@ export default function App() {
     setCounty(value);
     await fetchData(value);
     filter({
-      races,
-      //genders,
-      decisionPoints,
-      years,
-      offenses,
-      measurement,
+      decisionPoints: decisionPoints,
+      races: races,
+      offenses: offenses,
+      years: years,
+      measurement: measurement,
+      //genders: genders,
     });
   };
 
   const onYearChange = (values) => {
     setYears(values);
     filter({
-      races,
-      decisionPoints,
-      // genders,
+      decisionPoints: decisionPoints,
+      races: races,
+      offenses: offenses,
       years: values,
-      offenses,
-      measurement,
+      measurement: measurement,
+      //genders: genders,
     });
   };
 
@@ -358,12 +366,12 @@ export default function App() {
       });
     } else {
       filter({
-        races,
         decisionPoints: values,
-        offenses,
-        // genders,
-        years,
-        measurement,
+        races: races,
+        offenses: offenses,
+        years: years,
+        measurement: measurement,
+        //genders: genders,
       });
     }
   };
@@ -377,12 +385,12 @@ export default function App() {
       });
     } else {
       filter({
+        decisionPoints: decisionPoints,
         races: values,
-        decisionPoints,
-        // genders,
-        offenses,
-        years,
-        measurement,
+        offenses: offenses,
+        years: years,
+        measurement: measurement,
+        //genders: genders,
       });
     }
   };
@@ -408,18 +416,19 @@ export default function App() {
       });
     }
   };*/
+
   const onOffensesChange = (values) => {
     if (!values || values.length === 0) {
       return;
     }
     setOffenses(values);
     filter({
-      races,
-      // genders,
-      decisionPoints,
+      decisionPoints: decisionPoints,
+      races: races,
       offenses: values,
-      years,
-      measurement,
+      years: years,
+      measurement: measurement,
+      //genders: genders,
     });
   };
 
@@ -427,14 +436,14 @@ export default function App() {
     if (value) {
       setMeasurement(value);
       if (
-        value === "Disparity gap per population" ||
-        value === "Disparity gap per prior event point"
+        value === MEASUREMENTS.DG ||
+        value === MEASUREMENTS.DG_PEP
       ) {
         setChartConfig({
           base: "white",
           ratio: 0.01,
         });
-      } else if (value === "Raw numbers") {
+      } else if (value === MEASUREMENTS.RAW) {
         setChartConfig({
           base: null,
           ratio: 1,
@@ -447,27 +456,27 @@ export default function App() {
       }
 
       filter({
-        races,
-        //genders,
-        decisionPoints,
-        offenses,
-        years,
+        decisionPoints: decisionPoints,
+        races: races,
+        offenses: offenses,
+        years: years,
         measurement: value,
+        //genders: genders,
       });
     } else {
-      setMeasurement("Raw numbers");
+      setMeasurement(MEASUREMENTS.RAW);
       setChartConfig({
         base: null,
         ratio: 1,
       });
 
       filter({
-        races,
-        //genders,
-        decisionPoints,
-        offenses,
-        years,
-        measurement: "Raw numbers",
+        decisionPoints: decisionPoints,
+        races: races,
+        offenses: offenses,
+        years: years,
+        measurement: MEASUREMENTS.RAW,
+        //genders: genders,
       });
     }
   };

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -129,22 +129,6 @@ export default function App() {
     setShowTable(!showTable);
   };
 
-  const getRaces = (chart) => {
-    let _races = [];
-
-    for (let year of chart) {
-      for (let ep of year.data) {
-        for (let race in ep.items) {
-          if (!_races.includes(race)) {
-            _races.push(race)
-          }
-        }
-      }
-    }
-
-    return Object.fromEntries(Object.entries(RACES).filter(([key]) => _races.includes(key)));
-  };
-
   const filter = (
     { decisionPoints, races, offenses, years, measurement, genders },
     records = fullRecords,
@@ -624,7 +608,7 @@ export default function App() {
         ) : (
           <IconCharts
             data={filteredRecords.chart}
-            races={getRaces(filteredRecords.chart)}
+            races={Object.fromEntries(Object.entries(RACES).filter(([key]) => races.includes(key)))}
             base={chartConfig.base}
             measurement={measurement}
           />


### PR DESCRIPTION
Currently, whenever the user selects a new county, the other filters (year, race, event point, etc.) reset to their defaults. This PR makes it so that user selected filters should persist across county selection.