### PR TITLE
Update disclaimer text and improve multi-year labels

### DIFF
--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -19,6 +19,33 @@ const formatNumber = (n) => {
   }
 };
 
+const getYearsLabel = (years) => {
+  if (years.includes("All Years")) {
+    return "All Years (2010-2021)";
+  }
+
+  let years_list = [];
+  let last_year = [years[0], years[0]];
+  for (let i = 1; i < years.length; i++) {
+    if (parseInt(years[i]) === parseInt(years[i-1]) + 1) {
+      last_year[1] = years[i];
+    } else {
+      if (last_year[0] === last_year[1]) {
+        years_list.push(last_year[0]);
+      } else {
+        years_list.push(last_year.join("-"));
+      }
+      last_year = [years[i], years[i]];
+    }
+  }
+  if (last_year[0] === last_year[1]) {
+    years_list.push(last_year[0]);
+  } else {
+    years_list.push(last_year.join("-"));
+  }
+  return years_list.join(", ");
+};
+
 const PersonIcon = ({ value = 0, label = 0, race = "" }) => {
   const valueRoof = Math.ceil(value);
   const maskHeight = {
@@ -69,7 +96,7 @@ const PersonIcon = ({ value = 0, label = 0, race = "" }) => {
 const CHART_DISCLAIMER = {
   n_a: "A displayed value of N/A indicates there are 10 or fewer underlying observations for at least one of the variables needed to compute the metric.",
   zero: "A displayed value of 0.00 means that sufficient data is available, but the value is less than 0.005.",
-  pep: "No rate per prior event information is available for arrests because arrests are the beginning of the process.",
+  agg: "Data may not be available for all selected offenses for all selected years. Aggregate numbers reflect the combination of all available data. Select ‘View Data’ to see which data points are included in the aggregate data shown above.",
 };
 
 const MEASUREMENTS = {
@@ -125,7 +152,6 @@ const IconChartInner = ({ years, data, races, eventPoints, measurement, }) => {
   let disclaimers = {
     n_a: false,
     zero: false,
-    pep: measurement.indexOf("prior event point") > -1,
   };
 
   let scale = 1;
@@ -183,7 +209,7 @@ const IconChartInner = ({ years, data, races, eventPoints, measurement, }) => {
     postScaleString = "per " + (1 / scale).toLocaleString();
   }
 
-  const years_label = years.includes("All Years") ? "All Years" : years.join(", ");
+  const years_label = getYearsLabel(years);
 
   return (
     <div className="icon-chart" key={years_label}>
@@ -250,4 +276,4 @@ const IconCharts = ({ data, years, races, eventPoints, measurement }) => {
   );
 };
 
-export { IconCharts, PersonIcon };
+export { IconCharts, PersonIcon, getYearsLabel };

--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -94,8 +94,8 @@ const PersonIcon = ({ value = 0, label = 0, race = "" }) => {
 };
 
 const CHART_DISCLAIMER = {
-  n_a: "A displayed value of N/A indicates there are 10 or fewer underlying observations for at least one of the variables needed to compute the metric.",
-  zero: "A displayed value of 0.00 means that sufficient data is available, but the value is less than 0.005.",
+  n_a: "A displayed value of N/A indicates there are 10 or fewer underlying observations for at least one of the variables needed to compute the selected metric.",
+  zero: "A displayed value of 0.00 means that sufficient data is available to compute the selected metric, but its value is less than 0.005.",
   agg: "Data may not be available for all selected offenses, counties, and years. Aggregate numbers reflect the combination of all available data. Select ‘View Data’ to see which data points are included in the aggregate data shown above.",
 };
 

--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -96,7 +96,7 @@ const PersonIcon = ({ value = 0, label = 0, race = "" }) => {
 const CHART_DISCLAIMER = {
   n_a: "A displayed value of N/A indicates there are 10 or fewer underlying observations for at least one of the variables needed to compute the metric.",
   zero: "A displayed value of 0.00 means that sufficient data is available, but the value is less than 0.005.",
-  agg: "Data may not be available for all selected offenses for all selected years. Aggregate numbers reflect the combination of all available data. Select ‘View Data’ to see which data points are included in the aggregate data shown above.",
+  agg: "Data may not be available for all selected offenses, counties, and years. Aggregate numbers reflect the combination of all available data. Select ‘View Data’ to see which data points are included in the aggregate data shown above.",
 };
 
 const MEASUREMENTS = {
@@ -148,10 +148,11 @@ const scaleUp = (data) => {
   return SCALE[`${list[list.sort((a, b) => a - b).indexOf(max) + 1]}`];
 };
 
-const IconChartInner = ({ years, data, races, eventPoints, measurement, }) => {
+const IconChart = ({ data, years, races, eventPoints, measurement, agg }) => {
   let disclaimers = {
     n_a: false,
     zero: false,
+    agg: agg,
   };
 
   let scale = 1;
@@ -212,6 +213,7 @@ const IconChartInner = ({ years, data, races, eventPoints, measurement, }) => {
   const years_label = getYearsLabel(years);
 
   return (
+    <div className="icon-charts">
     <div className="icon-chart" key={years_label}>
       <h3>
         {years_label}
@@ -259,21 +261,8 @@ const IconChartInner = ({ years, data, races, eventPoints, measurement, }) => {
           ))}
       </div>
     </div>
-  );
-};
-
-const IconCharts = ({ data, years, races, eventPoints, measurement }) => {
-  return (
-    <div className="icon-charts">
-      <IconChartInner
-        years={years}
-        data={data}
-        races={races}
-        eventPoints={eventPoints}
-        measurement={measurement}
-      />
     </div>
   );
 };
 
-export { IconCharts, PersonIcon, getYearsLabel };
+export { IconChart, PersonIcon, getYearsLabel };

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import PublicGoogleSheetsParser from "public-google-sheets-parser";
 import { utils, writeFileXLSX } from "xlsx";
-import { IconCharts } from "@/components/IconCharts";
+import { IconCharts, getYearsLabel } from "@/components/IconCharts";
 import DataTable from "@/components/DataTable";
 import PrivateSelect from "@/components/Select";
 import Grid from "@/components/Grid";
@@ -472,7 +472,7 @@ export default function App() {
               decisionPoints.length === decisionPointsAvailable.length
                 ? "All Event Points"
                 : decisionPoints.join(", "),
-              years.join(", "),
+              getYearsLabel(years),
               races.length === racesAvailable.length
                 ? "All Races"
                 : races.join(", "),
@@ -480,7 +480,7 @@ export default function App() {
                 ? "All Offenses"
                 : (offenses.length <= 4
                   ? offenses.join(", ")
-                  : (offenses.length + " offenses: "
+                  : (offenses.length + " Offenses: "
                      + offenses[0] + ", ..., "
                      + offenses[offenses.length-1])
                 ),

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import PublicGoogleSheetsParser from "public-google-sheets-parser";
 import { utils, writeFileXLSX } from "xlsx";
-import { IconCharts, getYearsLabel } from "@/components/IconCharts";
+import { IconChart, getYearsLabel } from "@/components/IconCharts";
 import DataTable from "@/components/DataTable";
 import PrivateSelect from "@/components/Select";
 import Grid from "@/components/Grid";
@@ -497,7 +497,7 @@ export default function App() {
             <Grid />
           </div>
         ) : Object.keys(filteredRecords.chart).length > 0 ? (
-          <IconCharts
+          <IconChart
             data={filteredRecords.chart}
             years={years}
             races={Object.fromEntries(
@@ -505,6 +505,7 @@ export default function App() {
             )}
             eventPoints={decisionPoints}
             measurement={measurement}
+            agg={years.length > 1 || offenses.length > 1 || counties.length > 1}
           />
         ) : (
           <div style={{ textAlign: "center", fontWeight: "bold" }}>

--- a/src/pages/api/data.js
+++ b/src/pages/api/data.js
@@ -28,7 +28,7 @@ export default async function handler(req, res) {
     driver: sqlite3.Database,
   });
 
-  console.log("DB connection established");
+  console.log("API request at " + new Date(Date.now()));
   console.log(req.body);
   const body = JSON.parse(req.body);
 
@@ -127,5 +127,6 @@ export default async function handler(req, res) {
     }
   }
 
+  console.log("Returning " + rows.length + " rows.");
   res.status(200).json({raw: rows, chart: out});
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -144,7 +144,7 @@
 
 .icon-chart-disclaimer {
   color: #777;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .filters {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -144,7 +144,7 @@
 
 .icon-chart-disclaimer {
   color: #777;
-  font-size: 10px;
+  font-size: 13px;
 }
 
 .filters {


### PR DESCRIPTION
* Add a new disclaimer to explain what happens when multiple years/offenses/counties are aggregated with N/A values.
* Add a new function to label collections of years by ranges, not simple lists. For example, if the user selects the years 2018, 2019, and 2020, the tool will now display that as "2018-2020".
* Remove the now redundant "IconCharts" function, since multiple years are now aggregated into a single chart.