### PR TITLE
Harmonize measurement names across files

### DIFF
--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { MEASUREMENTS } from "@/components/Tool";
 
 const formatNumber = (n) => {
   const number = Number(n);
@@ -97,12 +98,6 @@ const CHART_DISCLAIMER = {
   n_a: "A displayed value of N/A indicates there are 10 or fewer underlying observations for at least one of the variables needed to compute the selected metric.",
   zero: "A displayed value of 0.00 means that sufficient data is available to compute the selected metric, but its value is less than 0.005.",
   agg: "Data may not be available for all selected offenses, counties, and years. Aggregate numbers reflect the combination of all available data. Select ‘View Data’ to see which data points are included in the aggregate data shown above.",
-};
-
-const MEASUREMENTS = {
-  RAW: "Raw numbers",
-  RATE: "Rate per population",
-  DG: "Population disparity v. White",
 };
 
 const scaleDown = (data) => {

--- a/src/pages/api/data.js
+++ b/src/pages/api/data.js
@@ -9,9 +9,9 @@ const ALLOW_NA = true;
 
 const MEASUREMENT_MAP = {
   "Raw numbers": "number",
-  "Rate per population": "rate_per_pop",
+  "Rate per unit population": "rate_per_pop",
   //"Rate per prior event point": "rate_cond_previous",
-  "Population disparity v. White": "disparity_gap_pop_w",
+  "Population disparity v. white": "disparity_gap_pop_w",
   //"Disparity gap per prior event point": "disparity_gap_cond_w",
 };
 


### PR DESCRIPTION
Recent changes to the names of the per-population and disparity metrics broke some functionality. This is a quick fix.