### PR TITLE
Change language to clarify how rate per population is annualized

### DIFF
--- a/src/components/IconCharts.js
+++ b/src/components/IconCharts.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { MEASUREMENTS } from "@/components/Tool";
 
 const formatNumber = (n, decimal=true) => {
   const number = Number(n);
@@ -147,13 +146,13 @@ const IconChart = ({ data, years, races, eventPoints, measurement, agg }) => {
 
   let scale = 1;
 
-  if (measurement === MEASUREMENTS.RAW) {
+  if (measurement === "RAW") {
     scale = scaleUp(data);
-  } else if (measurement === MEASUREMENTS.RATE) {
+  } else if (measurement === "RATE") {
     scale = scaleDown(data);
   }
 
-  const base = (measurement === MEASUREMENTS.DG) ? "white" : null;
+  const base = (measurement === "DG") ? "white" : null;
   const filteredRaces = Object.keys(races).filter(
     (raceItem) => raceItem.toLowerCase() !== base,
   );
@@ -192,7 +191,7 @@ const IconChart = ({ data, years, races, eventPoints, measurement, agg }) => {
   let postScaleString = "";
   if (scale < 1) {
     scaleString = "1";
-    postScaleString = "per " + formatNumber(1 / scale, false) + " population";
+    postScaleString = "per " + formatNumber(1 / scale, false) + " population per year";
   }
 
   const years_label = getYearsLabel(years);

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -9,7 +9,7 @@ import GenericPage from "@/components/GenericPage";
 
 export const MEASUREMENTS = {
   RAW: "Raw numbers",
-  RATE: "Rate per unit population",
+  RATE: "Annualized rate per unit population",
   DG: "Population disparity v. white",
   //R_PEP: "Rate per prior event point",
   //DG_PEP: "Disparity gap per prior event point",
@@ -25,7 +25,7 @@ export const DATA_COLUMNS = {
   //gender: "Gender",
   number: "Number",
   pop: "Population",
-  rate_pop: "Rate per 1,000 population per year",
+  rate_pop: "Annualized rate per 1,000 population",
   dg_pop: MEASUREMENTS.DG,
 };
 
@@ -64,7 +64,7 @@ const DEFAULTS = {
   decisionPoints: [...DECISION_POINTS],
   offenses: ["All Offenses"],
   races: Object.keys(RACES),
-  measurement: MEASUREMENTS.RAW,
+  measurement: "RAW",
 }
 
 const getURLQueryParameterByName = (name, url = window.location.href) => {
@@ -476,9 +476,9 @@ export default function App() {
             label="Measurement"
             value={measurement}
             onChange={onMeasurementChange}
-            options={Object.values(MEASUREMENTS).map((m) => ({
-              text: m,
-              value: m,
+            options={Object.entries(MEASUREMENTS).map(([k, v]) => ({
+              text: v,
+              value: k,
             }))}
           />
         </div>
@@ -490,7 +490,7 @@ export default function App() {
         <p
           dangerouslySetInnerHTML={{
             __html: [
-              measurement,
+              MEASUREMENTS[measurement],
               decisionPoints.length === decisionPointsAvailable.length
                 ? "All Event Points"
                 : decisionPoints.join(", "),

--- a/src/pages/api/data.js
+++ b/src/pages/api/data.js
@@ -7,19 +7,19 @@ const http = require("http"),
 
 const ALLOW_NA = true;
 
-const MEASUREMENT_MAP = {
-  "Raw numbers": "number",
-  "Rate per unit population": "rate_per_pop",
-  //"Rate per prior event point": "rate_cond_previous",
-  "Population disparity v. white": "disparity_gap_pop_w",
-  //"Disparity gap per prior event point": "disparity_gap_cond_w",
+const MEASUREMENTS = {
+  RAW: "number",
+  RATE: "rate_per_pop",
+  DG: "disparity_gap_pop_w",
+  //R_PEP: "rate_cond_previous",
+  //DG_PEP: "disparity_gap_cond_w",
 };
 
 const DEFAULTS = {
   counties: ["All Counties"],
   years: ["All Years"],
   offenses: ["459 PC-BURGLARY"],
-  measurement: "number",
+  measurement: MEASUREMENTS.RAW,
 };
 
 const config = ini.parse(fs.readFileSync('./config.ini', 'utf-8'));
@@ -65,7 +65,7 @@ export default async function handler(req, res) {
   query += ";";
 
   const measurement = ('measurement' in body ?
-    MEASUREMENT_MAP[body.measurement] : DEFAULTS.measurement);
+    MEASUREMENTS[body.measurement] : DEFAULTS.measurement);
 
   const doQuery = util.promisify(con.query).bind(con);
   const rows = await doQuery(query, vars);
@@ -103,7 +103,7 @@ export default async function handler(req, res) {
 
     data[r.race][r.decision][r.year][r.county].num += r.number;
 
-    if (measurement == 'disparity_gap_pop_w') {
+    if (measurement == MEASUREMENTS.DG) {
       data[r.race][r.decision][r.year][r.county].num_w += r.number_white;
     }
   }
@@ -123,11 +123,11 @@ export default async function handler(req, res) {
         }
       }
 
-      if (measurement === "number") {
+      if (measurement === MEASUREMENTS.RAW) {
         out[r][d] = agg.num;
-      } else if (measurement === "rate_per_pop") {
+      } else if (measurement === MEASUREMENTS.RATE) {
         out[r][d] = agg.num / agg.pop;
-      } else if (measurement === "disparity_gap_pop_w") {
+      } else if (measurement === MEASUREMENTS.DG) {
         out[r][d] = (agg.num / agg.pop) / (agg.num_w / agg.pop_w);
       }
     }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -269,7 +269,7 @@ export default function App() {
             </li>
             <li>
               <p>
-                <b>Rate per population</b> measures the rate at which a given event or decision occurs for a selected racial or ethnic group, relative to that group’s total population in the county. Specifically, it is the raw number of offense incidents of the requested type for the requested ethnic group during the requested year, per indicated number of individuals of that group in the county population, according to the following formula:
+                <b>Annualized rate per population</b> measures the rate at which a given event or decision occurs for a selected racial or ethnic group, relative to that group’s total population in the county. Specifically, it is the raw number of offense incidents of the requested type for the requested ethnic group during the requested year, per indicated number of individuals of that group in the county population, according to the following formula:
               </p>
               <p class="centered">rate per population = raw number / county population (race-specific)</p>
               <p> Population data come from the American Community Survey (ACS) 5-year estimates for the combined period 2016-2020. ACS summary tables were accessed through the Census Bureau API interface (see
@@ -296,6 +296,12 @@ export default function App() {
                 (burglary) during the year in question, and the Hispanic
                 population of county X was 100,000, the rate per 100 population
                 would be 350/(100,000/100) = 0.35 per 100 population.
+              </p>
+              <p>
+                In cases where data from more than one year are combined, the rate per population is annualized. That is, the rate is adjusted to represent the average number of incidents <b>per year</b> by dividing by the number of years in the query. In cases involving the year 2021 we only have 9 months of data, so that year is counted as 9/12 = 0.75 years of cases.
+              </p>
+              <p>
+                For example: Suppose we wanted to run the above example combining data for 2012, 2013, and 2014, and suppose there were 350 incidents in which Hispanic individuals had been arrested in county X on a charge of PC 459 (Burglary) during 2012, 250 such incidents during 2013, and 300 such incidents in 2014. The annualized rate per 100 population for that time frame would then be [(350+250+300)/3]/(100,000/100) = 0.30 per 100 population per year.
               </p>
             </li>
             <li>

--- a/to_db.py
+++ b/to_db.py
@@ -10,7 +10,7 @@ def clean_csv():
     df = df.drop(['rate_per_100_pop', 'disparity_gap_pop_w'], axis=1)
     df = df.assign(county=df.county.replace('California', 'All Counties'))
     df = df.assign(year=df.year.replace('All', 'All Years'))
-    df = df.assign(offense=df.offense.replace('All', 'All Offenses'))
+    df = df.assign(offense_name=df.offense_name.replace('All', 'All Offenses'))
     df = df.assign(decision=df.decision.replace('Court', 'Court action'))
 
     return df


### PR DESCRIPTION
Make the following changes:

- In the drop-down menu for Measurement, change "Rate per unit population" to "Annualized rate per unit population"
- In the upper left corner of the display, where it gives the scale for the little person, change "1 incident per xxx population" to "1 incident per xxx population per year"
- In the View Data table and the Download spreadsheet, change the header from "Rate per 1,000 population per year" to ""Annualized rate per 1,000 population"
- Add two paragraphs to Methodology to further explain how annualized rates are computed.